### PR TITLE
Fix iterating over received code actions

### DIFF
--- a/lua/code_action_menu/shared_utils.lua
+++ b/lua/code_action_menu/shared_utils.lua
@@ -39,7 +39,7 @@ local function request_servers_for_actions(use_range)
   ) or {}
   local all_actions = {}
 
-  for _, client_response in ipairs(all_responses) do
+  for _, client_response in pairs(all_responses) do
     for _, data in ipairs(client_response.result or {}) do
       local action
 


### PR DESCRIPTION
Responses from LSP clients are a table whose keys can start from some number (e.g. 3) instead of 0. Iterating with `ipairs` skips those keys.

![](https://user-images.githubusercontent.com/889383/135141879-c643a3c1-55d7-416e-b5c6-147f5a2ba998.png)

See #4 for more details.

The order of iteration does not matter, since the actions are sorted later anyway, so using `pairs` looks safe.

I am able to list all the actions that were shown previously in `:Telescope lsp_code_actions` or `:lua vim.lsp.buf.code_action()`:
![image](https://user-images.githubusercontent.com/889383/135144583-d54536c2-dd45-4755-9257-5738b93ab8bb.png)
(although it does not looks that great with my theme, but that's not related :smile: it's https://github.com/sainnhe/gruvbox-material)

Closes #4
Related to #2