### PR TITLE
Fix getting actions from all clients

### DIFF
--- a/lua/code_action_menu/utility_functions/actions.lua
+++ b/lua/code_action_menu/utility_functions/actions.lua
@@ -104,7 +104,7 @@ local function request_actions_from_all_servers(use_range)
   local all_clients = vim.lsp.buf_get_clients()
   local all_actions = {}
 
-  for _, client in ipairs(all_clients) do
+  for _, client in pairs(all_clients) do
     local action_data_objects = request_actions_from_server(client.id, request_parameters)
     local actions = parse_action_data_objects(client.id, action_data_objects)
     vim.list_extend(all_actions, actions)


### PR DESCRIPTION
The table of clients may be sparse and have empty slots. This can happen when LSP clients are restarted. When having 3 LSP clients started (ID 1, 2, 3) and doing `:LspRestart 3`, the 3rd client is stopped and a new client (with ID 4) is started. The final list of clients is 1, 2, 4. `ipairs` stops the iteration at 2 and does not iterate over the client with ID 4. `pairs` handles all clients in the table.

`pairs` is also safe to use because the loop does not rely on the index of the element.

This was previously fixed in https://github.com/weilbith/nvim-code-action-menu/pull/5 but looks like it regressed in https://github.com/weilbith/nvim-code-action-menu/commit/7361b5637930999d01b93b6ab4c45b784fa0618a#diff-2a5a390abbda6a3c4815db17a50f62a8d78b2567773ed6af509f65365b15745fR107