### PR TITLE
fix merging text document edits for same uri

### DIFF
--- a/lua/code_action_menu/lsp_objects/edits/workspace_edit.lua
+++ b/lua/code_action_menu/lsp_objects/edits/workspace_edit.lua
@@ -14,7 +14,7 @@ function WorkspaceEdit:add_text_document_edit(text_document_edit)
 
   for _, existing_text_document_edit in ipairs(self.all_text_document_edits) do
     if existing_text_document_edit.uri == text_document_edit.uri then
-      existing_text_document_edit.merge_text_document_edit_for_same_uri(
+      existing_text_document_edit:merge_text_document_edit_for_same_uri(
         text_document_edit
       )
       return


### PR DESCRIPTION
Use a lua method call instead of a function call to properly pass `self` and the argument (instead of passing the argument as `self` and nil as argument).

