### PR TITLE
Fix neovim 0.7+ support

### DIFF
--- a/lua/code_action_menu/lsp_objects/actions/code_action.lua
+++ b/lua/code_action_menu/lsp_objects/actions/code_action.lua
@@ -78,7 +78,7 @@ end
 
 function CodeAction:execute()
   if self:is_workspace_edit() then
-    vim.lsp.util.apply_workspace_edit(self.server_data.edit)
+    vim.lsp.util.apply_workspace_edit(self.server_data.edit, 'utf-8')
   elseif self:is_command() then
     vim.lsp.buf.execute_command(self.server_data.command)
   else


### PR DESCRIPTION
vim.lsp.util.apply_workspace_edit has an additional required argument now, offset_encoding. Setting the value to "utf-8". Maybe there's a better way to get the current encoding? But this works for now.

fixes #39