### PR TITLE
set local instead of global ones in code actions window

### DIFF
--- a/ftplugin/code-action-menu-menu.vim
+++ b/ftplugin/code-action-menu-menu.vim
@@ -20,7 +20,7 @@ call feedkeys('jk')
 augroup CodeActionMenuMenu
   autocmd!
   autocmd CursorMoved <buffer> lua require('code_action_menu').update_selected_action()
-  autocmd User CodeActionMenuWindowOpened ++once set scrolloff=0
-  autocmd User CodeActionMenuWindowOpened ++once set cursorline
-  autocmd User CodeActionMenuWindowOpened ++once set winhighlight=CursorLine:CodeActionMenuMenuSelection
+  autocmd User CodeActionMenuWindowOpened ++once setlocal scrolloff=0
+  autocmd User CodeActionMenuWindowOpened ++once setlocal cursorline
+  autocmd User CodeActionMenuWindowOpened ++once setlocal winhighlight=CursorLine:CodeActionMenuMenuSelection
 augroup END


### PR DESCRIPTION
Use `setlocal` instead of `set` to set vim options inside of the code-actions buffer.

This prevents overriding users global options and only applies the options inside the code-actions buffer.

To reproduce the problem:

1. `:set scrolloff=5`
2. Open the code-actions window
3. Close the code-actions window
4. `:verbose set scrolloff?`

On `main` it says:

```
  scrolloff=0
        Last set from ~/.local/share/nvim/site/pack/packer/opt/nvim-code-action-menu/ftplugin/code-action-menu-menu.vim line 23
```

With this fix:

```
  scrolloff=5

```

Fixes https://github.com/weilbith/nvim-code-action-menu/issues/40