### PR TITLE
Allow users to pass in custom diagnostics for the code action request

### DIFF
--- a/lua/code_action_menu.lua
+++ b/lua/code_action_menu.lua
@@ -39,13 +39,14 @@ local function close_warning_message_window()
   end
 end
 
-local function open_code_action_menu()
+local function open_code_action_menu(options)
   -- Might still be open.
   close_code_action_menu()
   close_warning_message_window()
 
-  local use_range = vim.api.nvim_get_mode().mode ~= 'n'
-  local all_actions = action_utils.request_actions_from_all_servers(use_range)
+  options = options or {}
+  options.use_range = vim.api.nvim_get_mode().mode ~= 'n'
+  local all_actions = action_utils.request_actions_from_all_servers(options)
 
   if #all_actions == 0 then
     warning_message_window_instace = WarningMessageWindow:new()

--- a/lua/code_action_menu/utility_functions/actions.lua
+++ b/lua/code_action_menu/utility_functions/actions.lua
@@ -101,17 +101,21 @@ local function request_actions_from_server(client_id, parameters)
   return action_objects or {}
 end
 
-local function request_actions_from_all_servers(use_range)
+local function request_actions_from_all_servers(options)
   vim.validate({
-    ['request action for range'] = { use_range, 'boolean', true },
+    ['options is table'] = { options, 't', true },
   })
 
-  local line_diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
-  local request_parameters = use_range
-      and vim.lsp.util.make_given_range_params()
+  options = options or {}
+  local request_parameters =
+    options.use_range
+    and vim.lsp.util.make_given_range_params()
     or vim.lsp.util.make_range_params()
 
-  request_parameters.context = { diagnostics = line_diagnostics }
+  local line_diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
+  request_parameters.context = {
+    diagnostics = options.diagnostics or line_diagnostics
+  }
 
   local all_clients = vim.lsp.buf_get_clients()
   local all_actions = {}


### PR DESCRIPTION
This mirrors the functionality provided by the `nvim.lsp.buf.code_action()` function, and is useful for providing non-local or external diagnostic information to the `textDocument/codeAction` request.

I've also merged the use_range parameter into the options struct, it seemed more lua-y that way.

Let me know what you think!