### PR TITLE
Strip newlines from lines passed to base window

### DIFF
--- a/lua/code_action_menu/windows/base_window.lua
+++ b/lua/code_action_menu/windows/base_window.lua
@@ -27,7 +27,10 @@ end
 function BaseWindow:update_buffer_content()
   vim.api.nvim_buf_clear_namespace(self.buffer_number, self.namespace_id, 0, -1)
 
-  local content = self:get_content()
+  local content = vim.tbl_map(
+    function(v) return v:gsub("\n"," ") end,
+    self:get_content()
+  )
 
   -- Unset and set the filtype option removes temporally th read-only property
   vim.api.nvim_buf_set_option(self.buffer_number, 'filetype', '')


### PR DESCRIPTION
vim.api.nvim_buf_set_lines explodes if final argument table contains strings with newlines. To prevent that, this commit replaces newlines with spaces before passing the data to it.