### PR TITLE
Use current selection for range actions

### DIFF
--- a/lua/code_action_menu/utility_functions/actions.lua
+++ b/lua/code_action_menu/utility_functions/actions.lua
@@ -101,6 +101,17 @@ local function request_actions_from_server(client_id, parameters)
   return action_objects or {}
 end
 
+local function get_range_request_parameters()
+  local selection_start = vim.fn.getpos('v')
+  local selection_end = vim.api.nvim_win_get_cursor(0)
+
+  return vim.lsp.util.make_given_range_params({
+    selection_start[2],
+    -- NOTE: getpos's column is 1-based, and we need 0-based
+    selection_start[3] - 1,
+  }, selection_end)
+end
+
 local function request_actions_from_all_servers(options)
   vim.validate({
     ['options is table'] = { options, 't', true },
@@ -109,7 +120,7 @@ local function request_actions_from_all_servers(options)
   options = options or {}
   local request_parameters =
     options.use_range
-    and vim.lsp.util.make_given_range_params()
+    and get_range_request_parameters()
     or vim.lsp.util.make_range_params()
 
   local line_diagnostics = vim.lsp.diagnostic.get_line_diagnostics()


### PR DESCRIPTION
This PR is a result of me trying to get TypeScript range code actions to work as in VSCode. I sometimes got them to work, but they didn't work reliably.

It turns out `vim.lsp.util.make_given_range_params` uses the **last** visual selection (because it uses the `>` and `<` registers which are not updated live, see https://github.com/neovim/neovim/blob/04c73dbedb8a82ed68ff0b0be32c2bee930fe529/runtime/lua/vim/lsp/util.lua#L1989-L1990) when asking LSP servers for range actions. This means the actions returned are outdated, because they are for the previous visual selection, not the current one.

A workaround to get the right actions is to select a region, `<Esc>`, and `gv` to re-select the previous region. Then, the current region will be the same as the last selection, and the correct range code actions will be returned. This is the behavior on `main`:


https://user-images.githubusercontent.com/889383/201074513-faa58508-33f0-4cc3-968e-fc45e2f5781e.mp4



This commit refactors the logic to use the current visual selection when asking for range code actions. The workaround is no longer needed. I can get range code actions in TypeScript:


https://user-images.githubusercontent.com/889383/201074235-9befb3f0-418f-4f6a-88e3-bca42e58962a.mp4

