### PR TITLE
fix(stacking_window): stabilize window widths on navigation

### DIFF
--- a/lua/code_action_menu/windows/stacking_window.lua
+++ b/lua/code_action_menu/windows/stacking_window.lua
@@ -117,8 +117,12 @@ function StackingWindow:after_opened()
   local last_window = self.window_stack[#self.window_stack]
 
   if not last_window.is_anchor then
-    local own_width = buffer_utils.get_buffer_width(self.buffer_number)
-    local last_width = buffer_utils.get_buffer_width(last_window.buffer_number)
+    -- NOTE: window widths are set inside each `:open()` call.
+    -- They could have been updated in previous `:after_opened()` for previous stacking windows.
+    -- We cannot rely on `buffer_utils.get_buffer_width`, because the width could have
+    -- been changed and be out of sync with the width suggested by the buffer contents.
+    local own_width = vim.api.nvim_win_get_width(self.window_number)
+    local last_width = vim.api.nvim_win_get_width(last_window.window_number)
 
     if last_width >= own_width then
       self:set_window_width(last_width)


### PR DESCRIPTION
## Context

The order of stacked windows is: menu, details, diff. The stacking window width was set sequentially for each window and relied only on the buffer content of the last window and the current window. This meant that when the diff window content was wider than the details window content, the diff window resized all windows in its stack (menu, details) to match the width of the diff window.

## Problem

This logic ignores the fact that the menu window could be wider than the details window. In such a situation, when the details window was being opened, it adjusted its width to match the width of the wider menu window. However, since the diff window only looked at buffer contents of the details window, and not at the actual window width of the details window, it assumed that the diff window is the widest one, and set the width of the menu window and the details window to match the diff window. This makes the menu window narrower than its content.


https://github.com/weilbith/nvim-code-action-menu/assets/889383/70514cd7-bb62-41a3-8c26-da45cf9ff8da




## Solution

Change the `StackingWindow:after_opened()` window resize logic to look at the *actual* window width, rather than the buffer content width. When `after_opened()` runs for the diff window, it correctly can identify that the details window was resized due to the menu window being wider, and correctly makes all windows' width be `max(diff window, previous windows)`.



https://github.com/weilbith/nvim-code-action-menu/assets/889383/4f4a2c7e-494a-4bae-b5c7-b432cbb9ddee





Fixes #52